### PR TITLE
Refactor auth, calendar, and notify for correctness and testability

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/pkg/browser"
 	"golang.org/x/oauth2"
@@ -15,82 +16,76 @@ import (
 
 const redirectURL = "http://localhost:8085/callback"
 
-// GetOAuthConfig returns the OAuth2 configuration
-func GetOAuthConfig() *oauth2.Config {
+func getOAuthConfig() (*oauth2.Config, error) {
+	if err := loadCredentials(); err != nil {
+		return nil, err
+	}
 	return &oauth2.Config{
-		ClientID:     ClientID(),
-		ClientSecret: ClientSecret(),
+		ClientID:     creds.Installed.ClientID,
+		ClientSecret: creds.Installed.ClientSecret,
 		RedirectURL:  redirectURL,
 		Scopes:       []string{calendar.CalendarReadonlyScope},
 		Endpoint:     google.Endpoint,
+	}, nil
+}
+
+// loadValidToken loads the stored token, refreshes it if needed, and saves it back.
+func loadValidToken(ctx context.Context, config *oauth2.Config) (*oauth2.Token, error) {
+	token, err := keyring.LoadToken()
+	if err != nil || token == nil {
+		return nil, fmt.Errorf("not logged in")
 	}
+	tokenSource := config.TokenSource(ctx, token)
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, fmt.Errorf("token expired, please login again")
+	}
+	if newToken.AccessToken != token.AccessToken {
+		if saveErr := keyring.SaveToken(newToken); saveErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not save refreshed token: %v\n", saveErr)
+		}
+	}
+	return newToken, nil
 }
 
 // IsLoggedIn checks if we have a valid token stored
 func IsLoggedIn(ctx context.Context) bool {
-	config := GetOAuthConfig()
-	token, err := keyring.LoadToken()
-	if err != nil || token == nil {
-		return false
-	}
-	// Check if token is valid or can be refreshed
-	tokenSource := config.TokenSource(ctx, token)
-	newToken, err := tokenSource.Token()
+	config, err := getOAuthConfig()
 	if err != nil {
 		return false
 	}
-	// Save refreshed token if needed
-	if newToken.AccessToken != token.AccessToken {
-		err := keyring.SaveToken(newToken)
-		if err != nil {
-			return false
-		}
-	}
-	return true
+	_, err = loadValidToken(ctx, config)
+	return err == nil
 }
 
 // GetClient returns an authenticated HTTP client.
 // It first tries to load a token from the keyring.
 // If no token exists or the token is invalid, it returns an error.
 func GetClient(ctx context.Context) (*http.Client, error) {
-	config := GetOAuthConfig()
-
-	// Try to load existing token from keyring
-	token, err := keyring.LoadToken()
-	if err != nil || token == nil {
-		return nil, fmt.Errorf("not logged in")
-	}
-
-	// Check if token is valid or can be refreshed
-	tokenSource := config.TokenSource(ctx, token)
-	newToken, err := tokenSource.Token()
+	config, err := getOAuthConfig()
 	if err != nil {
-		return nil, fmt.Errorf("token expired, please login again")
+		return nil, err
 	}
-
-	// Token is valid (possibly refreshed)
-	if newToken.AccessToken != token.AccessToken {
-		// Token was refreshed, save the new one
-		if saveErr := keyring.SaveToken(newToken); saveErr != nil {
-			fmt.Printf("Warning: could not save refreshed token: %v\n", saveErr)
-		}
+	token, err := loadValidToken(ctx, config)
+	if err != nil {
+		return nil, err
 	}
-	return config.Client(ctx, newToken), nil
+	return config.Client(ctx, token), nil
 }
 
 // Login initiates the OAuth2 flow and saves the token
 func Login(ctx context.Context) error {
-	config := GetOAuthConfig()
+	config, err := getOAuthConfig()
+	if err != nil {
+		return err
+	}
 	token, err := getTokenFromWeb(ctx, config)
 	if err != nil {
 		return fmt.Errorf("unable to get token from web: %w", err)
 	}
-
-	// Save token to keyring
 	if err := keyring.SaveToken(token); err != nil {
 		return fmt.Errorf("could not save token to keyring: %w", err)
 	}
-
 	return nil
 }
 

--- a/auth/credentials.go
+++ b/auth/credentials.go
@@ -56,21 +56,3 @@ func loadCredentials() error {
 	creds = &c
 	return nil
 }
-
-// ClientID returns the OAuth2 client ID
-func ClientID() string {
-	if err := loadCredentials(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	return creds.Installed.ClientID
-}
-
-// ClientSecret returns the OAuth2 client secret
-func ClientSecret() string {
-	if err := loadCredentials(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	return creds.Installed.ClientSecret
-}

--- a/calendar/calendar.go
+++ b/calendar/calendar.go
@@ -132,8 +132,7 @@ func FilterAccepted(events []*MeetingInfo) []*MeetingInfo {
 }
 
 // GetMeetingStatus calculates current and next meetings from a list of events
-func GetMeetingStatus(events []*MeetingInfo) *MeetingStatus {
-	now := time.Now()
+func GetMeetingStatus(events []*MeetingInfo, now time.Time) *MeetingStatus {
 	status := &MeetingStatus{}
 
 	for _, meeting := range events {

--- a/calendar/calendar_test.go
+++ b/calendar/calendar_test.go
@@ -261,26 +261,7 @@ func TestGetMeetingStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Since GetMeetingStatus uses time.Now() internally, we need to
-			// adjust our test events relative to the actual current time
-			// for the test to work correctly. We'll create adjusted events.
-			adjustedEvents := make([]*MeetingInfo, len(tt.events))
-			now := time.Now()
-			offset := now.Sub(fixedNow)
-
-			for i, evt := range tt.events {
-				if evt != nil {
-					adjustedEvents[i] = &MeetingInfo{
-						Summary:   evt.Summary,
-						Start:     evt.Start.Add(offset),
-						End:       evt.End.Add(offset),
-						Location:  evt.Location,
-						Attendees: evt.Attendees,
-					}
-				}
-			}
-
-			status := GetMeetingStatus(adjustedEvents)
+			status := GetMeetingStatus(tt.events, tt.now)
 
 			if status == nil {
 				t.Fatal("GetMeetingStatus returned nil")
@@ -330,7 +311,7 @@ func TestGetMeetingStatus_BoundaryConditions(t *testing.T) {
 			},
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		// !now.Before(meeting.Start) is true when now == Start
 		// now.Before(meeting.End) is true
@@ -353,7 +334,7 @@ func TestGetMeetingStatus_BoundaryConditions(t *testing.T) {
 			},
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		// !now.Before(meeting.Start) is true
 		// now.Before(meeting.End) is false when now == End
@@ -376,7 +357,7 @@ func TestGetMeetingStatus_BoundaryConditions(t *testing.T) {
 			},
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting == nil {
 			t.Fatal("expected meeting to be CurrentMeeting (ending soon)")
@@ -394,7 +375,7 @@ func TestGetMeetingStatus_BoundaryConditions(t *testing.T) {
 			},
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting == nil {
 			t.Fatal("expected meeting to be CurrentMeeting (1ns after start)")
@@ -413,7 +394,7 @@ func TestGetMeetingStatus_BoundaryConditions(t *testing.T) {
 			},
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting != nil {
 			t.Errorf("expected no CurrentMeeting for meeting starting soon")
@@ -450,7 +431,7 @@ func TestGetMeetingStatus_ReturnValueIntegrity(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				status := GetMeetingStatus(tc.events)
+				status := GetMeetingStatus(tc.events, now)
 				if status == nil {
 					t.Error("GetMeetingStatus should never return nil")
 				}
@@ -468,7 +449,7 @@ func TestGetMeetingStatus_ReturnValueIntegrity(t *testing.T) {
 		}
 		events := []*MeetingInfo{meeting}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting != meeting {
 			t.Error("CurrentMeeting should point to the original MeetingInfo pointer")
@@ -485,7 +466,7 @@ func TestGetMeetingStatus_ReturnValueIntegrity(t *testing.T) {
 		}
 		events := []*MeetingInfo{meeting}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.NextMeeting != meeting {
 			t.Error("NextMeeting should point to the original MeetingInfo pointer")
@@ -506,7 +487,7 @@ func TestGetMeetingStatus_LargeDataSets(t *testing.T) {
 			}
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting != nil {
 			t.Error("expected no CurrentMeeting for all past meetings")
@@ -526,7 +507,7 @@ func TestGetMeetingStatus_LargeDataSets(t *testing.T) {
 			}
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.NextMeeting == nil {
 			t.Fatal("expected NextMeeting to exist")
@@ -566,7 +547,7 @@ func TestGetMeetingStatus_LargeDataSets(t *testing.T) {
 			}
 		}
 
-		status := GetMeetingStatus(events)
+		status := GetMeetingStatus(events, now)
 
 		if status.CurrentMeeting == nil || status.CurrentMeeting.Summary != "Current" {
 			t.Errorf("expected CurrentMeeting 'Current', got %+v", status.CurrentMeeting)

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	// Calculate current/next meeting status from events (always fresh calculation)
-	status := calendar.GetMeetingStatus(events)
+	status := calendar.GetMeetingStatus(events, time.Now())
 
 	// Handle --notify flag
 	if *notifyThreshold != "" {
@@ -138,7 +138,7 @@ func buildParts(status *calendar.MeetingStatus) []string {
 	return parts
 }
 
-func getAndCacheEvents(ctx context.Context) (events []*calendar.MeetingInfo) {
+func getAndCacheEvents(ctx context.Context) []*calendar.MeetingInfo {
 	// Get authenticated client
 	client, err := auth.GetClient(ctx)
 	if err != nil {
@@ -152,17 +152,18 @@ func getAndCacheEvents(ctx context.Context) (events []*calendar.MeetingInfo) {
 	}
 
 	// Get events from API
-	events, err = calSvc.GetTodayEvents(ctx)
+	events, err := calSvc.GetTodayEvents(ctx)
 	if err != nil {
 		if isNetworkError(err) {
-			errorAndExit("📡 Calendar Offline", nil)
+			fmt.Fprintln(os.Stderr, "📡 Calendar Offline")
+			os.Exit(1)
 		}
 		errorAndExit("Error getting events: %v\n", err)
 	}
 
-	// Cache the events
+	// Cache the events (non-fatal if it fails)
 	if err := cache.Write(events); err != nil {
-		errorAndExit("Warning: failed to cache results: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Warning: failed to cache results: %v\n", err)
 	}
 	return events
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -11,7 +11,6 @@ import (
 	"image/png"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	"next-meeting/calendar"
@@ -24,55 +23,45 @@ const notifyDir = "next-meeting-notify"
 //go:embed icon.png
 var defaultIconBytes []byte
 
-var (
-	iconOnce        sync.Once
-	defaultIconPath string
-)
+func init() {
+	beeep.AppName = "Next Meeting"
+}
 
 func getNotifyDir() string {
 	return filepath.Join(os.TempDir(), notifyDir)
 }
 
 func ensureDefaultIcon() string {
-	iconOnce.Do(func() {
-		p := filepath.Join(os.TempDir(), "next-meeting-icon.png")
-		if _, err := os.Stat(p); err == nil {
-			defaultIconPath = p
-			return
-		}
-		if len(defaultIconBytes) == 0 {
-			defaultIconPath = ""
-			return
-		}
+	p := filepath.Join(os.TempDir(), "next-meeting-icon.png")
+	if _, err := os.Stat(p); err == nil {
+		return p
+	}
+	if len(defaultIconBytes) == 0 {
+		return ""
+	}
 
-		// Decode the embedded bytes and re-encode as truecolor PNG (NRGBA)
-		img, _, err := image.Decode(bytes.NewReader(defaultIconBytes))
-		if err != nil {
-			// fallback: write raw bytes
-			if err := os.WriteFile(p, defaultIconBytes, 0644); err != nil {
-				defaultIconPath = ""
-				return
-			}
-			defaultIconPath = p
-			return
+	// Decode the embedded bytes and re-encode as truecolor PNG (NRGBA)
+	img, _, err := image.Decode(bytes.NewReader(defaultIconBytes))
+	if err != nil {
+		// fallback: write raw bytes
+		if err := os.WriteFile(p, defaultIconBytes, 0644); err != nil {
+			return ""
 		}
+		return p
+	}
 
-		dst := image.NewNRGBA(img.Bounds())
-		draw.Draw(dst, dst.Bounds(), img, img.Bounds().Min, draw.Src)
+	dst := image.NewNRGBA(img.Bounds())
+	draw.Draw(dst, dst.Bounds(), img, img.Bounds().Min, draw.Src)
 
-		f, err := os.Create(p)
-		if err != nil {
-			defaultIconPath = ""
-			return
-		}
-		defer f.Close()
-		if err := png.Encode(f, dst); err != nil {
-			defaultIconPath = ""
-			return
-		}
-		defaultIconPath = p
-	})
-	return defaultIconPath
+	f, err := os.Create(p)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	if err := png.Encode(f, dst); err != nil {
+		return ""
+	}
+	return p
 }
 
 func getNotificationID(meeting *calendar.MeetingInfo) string {
@@ -101,7 +90,6 @@ func MarkNotified(meeting *calendar.MeetingInfo) error {
 }
 
 func SendNotification(meeting *calendar.MeetingInfo, startsIn time.Duration) error {
-	beeep.AppName = "Next Meeting"
 	body := "Upcoming meeting starting soon"
 	var title string
 	if startsIn < time.Minute {


### PR DESCRIPTION
- Fix garbled "📡 Calendar Offline" output caused by passing nil to a format string with no verb

- Demote cache write failure from fatal exit to a stderr warning, since events were fetched successfully

- Make GetMeetingStatus accept an explicit `now time.Time` parameter instead of calling time.Now() internally; simplifies tests by eliminating the time-offset adjustment workaround

- Replace os.Exit-calling ClientID/ClientSecret with getOAuthConfig() returning an error, so credential failures propagate normally

- Extract loadValidToken() to eliminate duplicated token-refresh logic between IsLoggedIn and GetClient

- Move beeep.AppName assignment to an init() function

- Simplify ensureDefaultIcon by removing the unnecessary sync.Once

- Remove named return from getAndCacheEvents