### PR TITLE
chore: update Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module next-meeting
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gen2brain/beeep v0.11.2


### PR DESCRIPTION
## Go version update

Bumps Go to **1.26.5**.

### Changes
- go.mod: go 1.26.4 → go 1.26.5

_Automated PR by update-go-version.sh_